### PR TITLE
Hide verbose logging & remove usage string from application errors

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"io"
 	"log"
 	"os"
@@ -24,6 +23,8 @@ func NewRootCmd() *cobra.Command {
 		Short: "",
 		Long:  ``,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			cmd.SilenceUsage = true
+
 			if !gf.verbose {
 				log.SetOutput(io.Discard)
 			}
@@ -46,7 +47,7 @@ func Execute() {
 	cmd := NewRootCmd()
 
 	if err := cmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		cmd.PrintErrln("Error:", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,7 +47,6 @@ func Execute() {
 	cmd := NewRootCmd()
 
 	if err := cmd.Execute(); err != nil {
-		cmd.PrintErrln("Error:", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,9 @@ func NewRootCmd() *cobra.Command {
 		Short: "",
 		Long:  ``,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			// PersistentPreRun seems to be run after the FlagError functions have been called.
+			// The usage shall be printed if there is an error in the usage (e.g., flags are missing)
+			// But shall not printed if the RunE functions return errors (i.e. application errors)
 			cmd.SilenceUsage = true
 
 			if !gf.verbose {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"log"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -11,19 +13,27 @@ type globalFlags struct {
 	ip          string
 	port        string
 	interactive bool
+	verbose     bool
 }
 
 func NewRootCmd() *cobra.Command {
+	gf := &globalFlags{}
+
 	cc := &cobra.Command{
 		Use:   "crypta",
 		Short: "",
 		Long:  ``,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if !gf.verbose {
+				log.SetOutput(io.Discard)
+			}
+		},
 	}
 
-	gf := &globalFlags{}
 	cc.PersistentFlags().StringVar(&gf.ip, "ip", "127.0.0.1", "IP to bind daemon")
 	cc.PersistentFlags().StringVar(&gf.port, "port", "35997", "Port to bind daemon")
 	cc.PersistentFlags().BoolVar(&gf.interactive, "interactive", true, "Allow user input")
+	cc.PersistentFlags().BoolVarP(&gf.verbose, "verbose", "v", false, "Enable verbose logging")
 
 	cc.AddCommand(NewDaemonCmd(gf))
 	cc.AddCommand(NewGetCmd(gf))
@@ -36,7 +46,7 @@ func Execute() {
 	cmd := NewRootCmd()
 
 	if err := cmd.Execute(); err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/pkg/daemon/client.go
+++ b/pkg/daemon/client.go
@@ -66,7 +66,9 @@ func NewDaemonClient(ip string, port string) *daemonClient {
 
 	// hook the retries in order to inform the user
 	c.RequestLogHook = func(l retryablehttp.Logger, r *http.Request, i int) {
-		log.Printf("Daemon currently not reachable. Retry %d of %d...\n", i+1, c.RetryMax+1)
+		if i > 0 {
+			log.Printf("Daemon currently not reachable. Retry %d of %d...\n", i, c.RetryMax+1)
+		}
 	}
 
 	return &daemonClient{

--- a/pkg/daemon/client.go
+++ b/pkg/daemon/client.go
@@ -67,7 +67,7 @@ func NewDaemonClient(ip string, port string) *daemonClient {
 	// hook the retries in order to inform the user
 	c.RequestLogHook = func(l retryablehttp.Logger, r *http.Request, i int) {
 		if i > 0 {
-			log.Printf("Daemon currently not reachable. Retry %d of %d...\n", i, c.RetryMax+1)
+			log.Printf("Daemon currently not reachable. Retry %d of %d...\n", i, c.RetryMax)
 		}
 	}
 

--- a/test/e2e/crypta_test.go
+++ b/test/e2e/crypta_test.go
@@ -159,7 +159,7 @@ var _ = Describe("Crypta", func() {
 		}
 
 		checkErrOutputForRetries := func(out string) {
-			for i := 1; i <= 5; i++ {
+			for i := 1; i < 5; i++ {
 				Expect(out).To(ContainSubstring(fmt.Sprintf("Daemon currently not reachable. Retry %d of 5...", i)))
 			}
 		}

--- a/test/e2e/crypta_test.go
+++ b/test/e2e/crypta_test.go
@@ -159,8 +159,8 @@ var _ = Describe("Crypta", func() {
 		}
 
 		checkErrOutputForRetries := func(out string) {
-			for i := 1; i < 5; i++ {
-				Expect(out).To(ContainSubstring(fmt.Sprintf("Daemon currently not reachable. Retry %d of 5...", i)))
+			for i := 1; i <= 4; i++ {
+				Expect(out).To(ContainSubstring(fmt.Sprintf("Daemon currently not reachable. Retry %d of 4...", i)))
 			}
 		}
 

--- a/test/e2e/crypta_test.go
+++ b/test/e2e/crypta_test.go
@@ -193,6 +193,16 @@ var _ = Describe("Crypta", func() {
 			checkErrOutputForConnectionTimeout(errOutput)
 			checkErrOutputForRetries(errOutput)
 		})
+		By("trying to retrieve a value and not print the usage", func() {
+			errOutput := startCrypta("get", "abcd")
+			Expect(errOutput).To(Not(BeEmpty()))
+			Expect(errOutput).To(Not(ContainSubstring("Usage:")))
+		})
+		By("trying to set a value and not print the usage", func() {
+			errOutput := startCrypta("set", "abcd", "xyz")
+			Expect(errOutput).To(Not(BeEmpty()))
+			Expect(errOutput).To(Not(ContainSubstring("Usage:")))
+		})
 	})
 
 	Describe("An initial value set via environment variables can be retrieved", Ordered, func() {
@@ -210,4 +220,35 @@ var _ = Describe("Crypta", func() {
 			Ω(getValue(key)).Should(Equal(val + "\n"))
 		})
 	})
+
+	Describe("A usage message shall be printed if", func() {
+		It("receives a wrong flag", func() {
+			cmd := exec.Command(pathToCrypta, "get", "--unknown")
+			crypta, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Ω(err).ShouldNot(HaveOccurred())
+
+			Eventually(crypta).Should(gexec.Exit(1))
+
+			errStr := string(crypta.Err.Contents())
+
+			Expect(crypta.Out.Contents()).To(BeEmpty())
+			Expect(errStr).To(Not(BeEmpty()))
+			Expect(errStr).To(ContainSubstring("Usage:"))
+		})
+
+		It("is missing a required argument", func() {
+			cmd := exec.Command(pathToCrypta, "get")
+			crypta, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Ω(err).ShouldNot(HaveOccurred())
+
+			Eventually(crypta).Should(gexec.Exit(1))
+
+			errStr := string(crypta.Err.Contents())
+
+			Expect(crypta.Out.Contents()).To(BeEmpty())
+			Expect(errStr).To(Not(BeEmpty()))
+			Expect(errStr).To(ContainSubstring("Usage:"))
+		})
+	})
+
 })

--- a/test/e2e/crypta_test.go
+++ b/test/e2e/crypta_test.go
@@ -29,8 +29,14 @@ func initDaemon(setCmdEnv func(*exec.Cmd)) {
 
 func defaultEnv(*exec.Cmd) {}
 
+func setTestDaemonTimeout(c *exec.Cmd) {
+	c.Env = os.Environ()
+	c.Env = append(c.Env, "CRYPTA_TIMEOUT=0.1")
+}
+
 func setValue(key, val string) {
 	cmd := exec.Command(pathToCrypta, "set", key, val)
+	setTestDaemonTimeout(cmd)
 	crypta, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 	Ω(err).ShouldNot(HaveOccurred())
 
@@ -39,6 +45,7 @@ func setValue(key, val string) {
 
 func getValue(key string) string {
 	cmd := exec.Command(pathToCrypta, "get", key)
+	setTestDaemonTimeout(cmd)
 	crypta, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 	Ω(err).ShouldNot(HaveOccurred())
 

--- a/test/e2e/crypta_test.go
+++ b/test/e2e/crypta_test.go
@@ -249,6 +249,20 @@ var _ = Describe("Crypta", func() {
 			Expect(errStr).To(Not(BeEmpty()))
 			Expect(errStr).To(ContainSubstring("Usage:"))
 		})
+
+		It("is called with help", func() {
+			cmd := exec.Command(pathToCrypta, "help")
+			crypta, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Ω(err).ShouldNot(HaveOccurred())
+
+			Eventually(crypta).Should(gexec.Exit(0))
+
+			outStr := string(crypta.Out.Contents())
+
+			Expect(outStr).To(Not(BeEmpty()))
+			Expect(outStr).To(ContainSubstring("Usage:"))
+			Expect(crypta.Err.Contents()).To(BeEmpty())
+		})
 	})
 
 })


### PR DESCRIPTION
## What's Changed

- Log messages, e.g., when the daemon could not be reached, were always printed. A new "verbose" flag has been introduced which enables these log messages now.
- The usage string has been printed for all kinds of errors. It is now only printed if the actual usage is incorrect. It is not printed anymore for application errors. Help is printed to stdout.
- The retry timeout has been reduced for all e2e tests, as the current default of 1s would exceed the ginkgo test timeout of 1s if the daemon is not reachable at the start.

## Todo

- [x] The pull request title is in the following format: `Add new feature`
- [x] A label (`breaking`, `feature`, `bug`, `chore`) indicating the type of the change has been added
